### PR TITLE
일반 로그인시 화면이동이 안되는 문제 해결

### DIFF
--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -110,11 +110,11 @@ export default function LoginForm({ navigate }) {
     if (accessToken) {
       setAccessToken(accessToken);
 
-      const itmes = await cartStore.fetchCart();
+      const itmes = await cartStore.fetchCart(accessToken);
 
       setCart(itmes);
 
-      navigate('-1');
+      navigate(-1);
     }
   };
 

--- a/src/components/MyPageNavigation.jsx
+++ b/src/components/MyPageNavigation.jsx
@@ -35,11 +35,11 @@ export default function MyPageNavigation() {
             <li>
               <Link to="/my">주문 목록</Link>
             </li>
-            <li>개인 정보 관리</li>
+            {/* <li>개인 정보 관리</li> */}
             <li>
               <Link to="/my/review/writeable">리뷰 관리</Link>
             </li>
-            <li>문의 관리</li>
+            {/* <li>문의 관리</li> */}
           </ul>
         </Menu>
       </Navigation>

--- a/src/stores/CartStore.js
+++ b/src/stores/CartStore.js
@@ -14,7 +14,9 @@ export default class CartStore extends Store {
     apiService.updateCart(JSON.stringify(this.cart));
   }
 
-  async fetchCart() {
+  async fetchCart(accessToken) {
+    apiService.setAccessToken(accessToken);
+
     const { items } = await apiService.fetchCart();
     this.cart = new Cart(JSON.parse(items));
     this.publish();


### PR DESCRIPTION
원인: 로그인 시, 서버에서 accessToken을 받아 저장하는데 저장하기 전에 accessToken이 필요한 fetchCart를 요청했기 때문

해결: fetchCart를 하기전에 accessToken이 저장되도록 수정